### PR TITLE
Use OIDC to connect to octopus

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to obtain the ID token from GitHub Actions
+      contents: read # Required to check out code
+      checks: write # Required for test-reporter
     env:
       OCTOPUS_SPACE: "Core Platform"
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # Daily 5am australian/brisbane time
     - cron: '0 19 * * *'
+  workflow_dispatch:
 
 env:
   OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }} # For pull_request events we override the /refs/pull/xx/merge branch to the PR's head branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      OCTOPUS_API_KEY: ${{ secrets.DEPLOY_API_KEY }}
-      OCTOPUS_URL: ${{ secrets.DEPLOY_URL }}
       OCTOPUS_SPACE: "Core Platform"
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +32,7 @@ jobs:
       # Adjustment is done prior to Nuke build as OCTOVERSION information is included in the result package.
       - name: Append OCTOVERSION_CurrentBranch with -nightly (for scheduled)
         if: github.event_name == 'schedule'
-        run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly" >> $GITHUB_ENV
+        run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
       - name: Nuke Build 🏗
         id: build
@@ -66,13 +64,22 @@ jobs:
               sha: context.sha
             })
 
+      - name: Login to Octopus Deploy 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
+        uses: OctopusDeploy/login@v1
+        with: 
+          server: https://deploy.octopus.app
+          service_account_id: 6e5497b3-8427-42b4-a354-e05ea095f7c1
+
       - name: Push to Octopus 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         uses: OctopusDeploy/push-package-action@v3
         with:
           packages: |
             ./artifacts/NCrontab.Advanced.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
 
       - name: Create Release in Octopus 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         uses: OctopusDeploy/create-release-action@v3
         with:
           project: "Ncron.Advanced"


### PR DESCRIPTION
## Background

Our API keys periodically expire, breaking things.

## Results

Octopus now supports OIDC for github actions, with wildcards on permitted branches, enabling us to authenticate via OIDC and remove the need for API keys entirely.

Also syncs minor other build script changes to standardize the build:

- timestamp nightlies
- enable workflow_dispatch
- don't push to octopus on PR validation